### PR TITLE
Reformatted and added comments to fenwick.cpp

### DIFF
--- a/Templates/structs/fenwick.cpp
+++ b/Templates/structs/fenwick.cpp
@@ -2,24 +2,14 @@
 using namespace std;
 
 struct BIT {
-    int n,rtn;
+    int n, rtn; // rtn might need to be LLed
     vector<int> bit;
-    BIT(int n) : n(n), bit(n+1,0) {}
-    void update(int x, int d) { for (int i=x;i<=n;i+=i&-i) bit[i]+=d; }
+    BIT(int n) : n(n), bit(n + 1,0) {}
+    void update(int x, int d) { for (int i = x; i <= n; i += i & -i) bit[i] += d; }
     int query(int x) {
-        rtn=0;
-        for (int i=x;i;i-=i&-i) rtn+=bit[i];
+        rtn = 0;
+        for (int i = x; i; i -= i & -i) rtn += bit[i];
         return rtn;
     }
-    int query(int x, int y) { return query(y) - query(x-1); }
+    int query(int x, int y) { return query(y) - query(x - 1); }
 };
-
-int main()
-{
-    ios_base::sync_with_stdio(0); cin.tie(0);
-    int n;
-    //BIT bit(n);
-    //bit.update(i,d);
-    //bit.query(l,r);
-    return 0;
-}


### PR DESCRIPTION
Spacing didn't match other templates and added a comment as rtn variable can overflow if not set correctly.